### PR TITLE
Handle templates within script tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,19 @@ function getBaseNameFromUrl(url) {
 
 var injectTemplates = function(templates) {
     templates.forEach(function(tpl) {
-        var s = document.createElement('script');
-        s.id = tpl.id;
-        s.innerHTML = tpl.content;
-        s.type = 'text/html';
-        document.head.appendChild(s);
+        if (tpl.content.trim().slice(0, 7) === '<script') {
+            var s = document.createElement('head');
+            s.innerHTML = tpl.content;
+            while (s.firstElementChild) {
+                document.head.appendChild(s.firstElementChild);
+            }
+        } else {
+            var s = document.createElement('script');
+            s.id = tpl.id;
+            s.innerHTML = tpl.content;
+            s.type = 'text/html';
+            document.head.appendChild(s);
+        }
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function getBaseNameFromUrl(url) {
 var injectTemplates = function(templates) {
     templates.forEach(function(tpl) {
         var s;
-        if (tpl.content.trim().slice(0, 7) === '<script') {
+        if ((/^<script/i).test(tpl.content.trim())) {
             s = document.createElement('head');
             s.innerHTML = tpl.content;
             var nestedScriptElements = s.getElementsByTagName('script');

--- a/index.js
+++ b/index.js
@@ -4,14 +4,16 @@ function getBaseNameFromUrl(url) {
 
 var injectTemplates = function(templates) {
     templates.forEach(function(tpl) {
+        var s;
         if (tpl.content.trim().slice(0, 7) === '<script') {
-            var s = document.createElement('head');
+            s = document.createElement('head');
             s.innerHTML = tpl.content;
-            while (s.firstElementChild) {
-                document.head.appendChild(s.firstElementChild);
+            var nestedScriptElements = s.getElementsByTagName('script');
+            while (nestedScriptElements.length > 0) {
+                document.body.appendChild(nestedScriptElements[0]);
             }
         } else {
-            var s = document.createElement('script');
+            s = document.createElement('script');
             s.id = tpl.id;
             s.innerHTML = tpl.content;
             s.type = 'text/html';


### PR DESCRIPTION
Handle templates that are already within a script tags.
In rare cases, I've had a template and a "sub-template" as separate script tags within the same .ko file (e,g. https://github.com/Munawwar/lithium-ui/blob/master/components/Dropdown.ko). If that isn't easy to support then I am ok with assuming single script. 
